### PR TITLE
Fix two problems with Spanish locale and PostgreSQL during the installation

### DIFF
--- a/resources/debian/postinst
+++ b/resources/debian/postinst
@@ -45,13 +45,13 @@ setup_postgresql() {
     pushd /tmp > /dev/null
 
     # Generate en_US-UTF-8 locale in case it's not in the system yet
-    locale-gen --no-purge en_US.UTF-8
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
     # Check whether nuxeo cluster already exists
     nxcluster=$(pg_lsclusters -h | grep $PGCLUSTER) || true
     if [ -z "$nxcluster" ]; then
         # get postgresql version
-        pgversion=$(psql --version | awk '{print $3}' | sed -E 's/([0-9]+\.[0-9]+).*/\1/')
+        pgversion=$(psql --version | sed -n '1p' | awk '{print $3}' | sed -E 's/([0-9]+\.[0-9]+).*/\1/')
         if [ -z "$pgversion" ]; then
             pgversion=$PGDEFAULTVERSION
         fi


### PR DESCRIPTION
If I should report this issue before the pull request, please let me know.

I have had the two problems during nexeo installation on a Debian Wheezy (7.7) machine. I have solved them with the following changes.
